### PR TITLE
(chore) Add test for nested text elements

### DIFF
--- a/src/index.test.js
+++ b/src/index.test.js
@@ -262,6 +262,25 @@ describe('#jsx-pdf', () => {
         },
       });
     });
+
+    it('should support nested text elements in the stack', () => {
+      expect(
+        toPDFMake(
+          <document>
+            <content>
+              <text>
+                <text>first</text>
+                <text>second</text>
+              </text>
+            </content>
+          </document>,
+        ),
+      ).toEqual({
+        content: {
+          stack: [{ text: [{ text: 'first' }, { text: 'second' }] }],
+        },
+      });
+    });
   });
 
   it('should ignore falsy values', () => {


### PR DESCRIPTION
Before this test, the unwrapTextElements function was not fully tested, as it almost always receives a one-element array and unwraps it.  The alternative path returning the original array is exercised by this test.