### PR TITLE
Fix description on npmjs.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/jsx-pdf.svg)](https://www.npmjs.com/jsx-pdf) [![Build Status](https://travis-ci.org/schibsted/jsx-pdf.svg?branch=master)](https://travis-ci.org/schibsted/jsx-pdf) [![Coverage Status](https://coveralls.io/repos/github/schibsted/jsx-pdf/badge.svg?branch=master)](https://coveralls.io/github/schibsted/jsx-pdf?branch=master)
 
-This library allows you to generate PDFs using a react-like JSX syntax.
+This library allows you to generate modular PDFs using JSX.
 
 ```jsx
 import { createElement, createRenderer } from 'jsx-pdf';

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "jsx-pdf",
   "version": "1.0.0",
   "main": "dst/index.js",
+  "description": "Generate modular PDFs using JSX.",
   "files": [
     "/dst",
     "/fonts"


### PR DESCRIPTION
Added the description in package json for searchability using `npm search`
Current:
![image](https://user-images.githubusercontent.com/412744/43728453-0c378db8-999d-11e8-963a-e0e7b006a6fa.png)

I'm not sure if it's this or whether we'll need an update to the README.md to fix it. npm docs aren't explicit.
