### PR TITLE
add QR Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,22 @@ const doc = (
 );
 ```
 
+### QR Codes
+
+The `qr` tag can be used to render QR codes. There are various options available as described in the [pdfmake docs](https://pdfmake.github.io/docs/0.1/document-definition-object/qr/).
+
+```jsx
+import JsxPdf from 'jsx-pdf';
+
+const doc = (
+  <document>
+    <content>
+      <qr content="My text" />
+    </content>
+  </document>
+);
+```
+
 ## API
 
 ### renderPdf

--- a/src/index.js
+++ b/src/index.js
@@ -135,6 +135,8 @@ function resolveChildren(tag, parentContext, isTopLevel) {
       return { image: attributes.src, ...omit(attributes, 'src') };
     case 'svg':
       return { svg: attributes.content, ...omit(attributes, 'content') };
+    case 'qr':
+      return { qr: attributes.content, ...omit(attributes, 'content') };
     case 'table':
       return {
         table: {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -879,6 +879,49 @@ describe('#jsx-pdf', () => {
       });
     });
 
+    describe('qr', () => {
+      it('should be converted', () => {
+        expect(
+          JsxPdf.renderPdf(
+            <document>
+              <content>
+                <qr content="my text" />
+              </content>
+            </document>,
+          ),
+        ).toEqual({
+          content: {
+            stack: [
+              {
+                qr: 'my text',
+              },
+            ],
+          },
+        });
+      });
+
+      it('should set passed attributes', () => {
+        expect(
+          JsxPdf.renderPdf(
+            <document>
+              <content>
+                <qr content="my text" foreground="#f9c7bf" />
+              </content>
+            </document>,
+          ),
+        ).toEqual({
+          content: {
+            stack: [
+              {
+                qr: 'my text',
+                foreground: '#f9c7bf',
+              },
+            ],
+          },
+        });
+      });
+    });
+
     describe('stack', () => {
       it('should be converted', () => {
         expect(


### PR DESCRIPTION
This PR adds support for [QR Codes](https://pdfmake.github.io/docs/0.1/document-definition-object/qr/) using the `<qr />` element. This is very similar to `<svg />`


Also, any chance you could release the lastest updates to this lib? :) 

Thanks